### PR TITLE
Call addIsConnected when building NTMultiChannel

### DIFF
--- a/src/pvaClientNTMultiData.cpp
+++ b/src/pvaClientNTMultiData.cpp
@@ -57,7 +57,7 @@ PvaClientNTMultiData::PvaClientNTMultiData(
          unionValue[i] = pvDataCreate->createPVUnion(u);
     }
     NTMultiChannelBuilderPtr builder = NTMultiChannel::createBuilder();
-    builder->value(u);
+    builder->value(u)->addIsConnected();
     if(pvRequest->getSubField("field.alarm"))
     {
          gotAlarm = true;


### PR DESCRIPTION
isConnected is not a required field of NTMultiChannel, so an instance of NTMultiChannel wrapper class in normativeTypesCPP built by the builder does not have this by default and addIsConnected must be called to provide this field.