### PR TITLE
Use EPICS_DEPRECATED macro

### DIFF
--- a/src/pv/pvaClient.h
+++ b/src/pv/pvaClient.h
@@ -18,6 +18,7 @@
 
 #include <list>
 #include <iostream>
+#include <compilerDependencies.h>
 #include <pv/requester.h>
 #include <pv/status.h>
 #include <pv/event.h>
@@ -107,11 +108,10 @@ public:
      * \deprecated This method will go away in future versions. Use get instead.
      * @return shared pointer to the single instance
      */
-    static PvaClientPtr create()
-     {
-         std::cerr << "create is deprecated. Use get instead\n";
-         return get("pva ca");
-     }
+    static PvaClientPtr create() EPICS_DEPRECATED
+    {
+        return get("pva ca");
+    }
     /** Get the requester name.
      * @return The name.
      */


### PR DESCRIPTION
Don't print error messages when a deprecated function is called,
make it a compile-time warning instead.

This change is necessary because pvaPy cannot switch to the new API without adding conditional compilation (since it promises to build on older versions of the other V4 modules). Until the pvaClient version number changes and Sinisa can make the necessary code changes inside pvaPy a build warning is acceptable, but printing the error at runtime is not.
