### PR TITLE
fix pvaClientChannel and pvaClientMonitor bugs

### DIFF
--- a/src/pv/pvaClient.h
+++ b/src/pv/pvaClient.h
@@ -1378,7 +1378,7 @@ private:
         epics::pvData::PVStructurePtr const &pvRequest);
 
     void checkMonitorState();
-    enum MonitorConnectState {connectIdle,connectActive,connected,monitorStarted};
+    enum MonitorConnectState {connectIdle,connectActive,connected};
 
     PvaClient::weak_pointer pvaClient;
     epics::pvAccess::Channel::weak_pointer channel;
@@ -1389,6 +1389,7 @@ private:
     PvaClientMonitorDataPtr pvaClientData;
 
     bool isDestroyed;
+    bool isStarted;
     epics::pvData::Status connectStatus;
     epics::pvData::MonitorPtr monitor;
     epics::pvData::MonitorElementPtr monitorElement;

--- a/src/pvaClientChannel.cpp
+++ b/src/pvaClientChannel.cpp
@@ -224,6 +224,7 @@ void PvaClientChannel::channelCreated(const Status& status, Channel::shared_poin
            << endl;
     }
     Lock xx(mutex);
+    if(connectState==connected) return;
     if(connectState!=connectActive) {
          string message("PvaClientChannel::channelCreated");
          message += " channel " + channelName


### PR DESCRIPTION
If channel is already connected when channelCreated is called then just return.

pvaClientMonitor was not reporting the first monitor when monitor is created or a re-connection occurs.