### PR TITLE
stateChangeRequester; semantics for unlisten and channelStateChange

### DIFF
--- a/src/pvaClientChannel.cpp
+++ b/src/pvaClientChannel.cpp
@@ -213,7 +213,6 @@ PvaClientChannel::~PvaClientChannel()
     if(PvaClient::getDebug()) showCache();
 }
 
-
 void PvaClientChannel::channelCreated(const Status& status, Channel::shared_pointer const & channel)
 {
     if(PvaClient::getDebug()) {
@@ -252,6 +251,12 @@ void PvaClientChannel::channelStateChange(
         << " " << Channel::ConnectionStateNames[connectionState]
         << endl;
     }
+    PvaClientChannelStateChangeRequesterPtr req(stateChangeRequester.lock());
+    if(req) {
+         bool value = (connectionState==Channel::CONNECTED ? true :  false);
+         req->channelStateChange(shared_from_this(),value);
+    }
+   
     Lock xx(mutex);
     bool waitingForConnect = false;
     if(connectState==connectActive) waitingForConnect = true;
@@ -291,6 +296,12 @@ string PvaClientChannel::getChannelName()
 Channel::shared_pointer PvaClientChannel::getChannel()
 {
     return channel;
+}
+
+void PvaClientChannel::setStateChangeRequester(
+    PvaClientChannelStateChangeRequesterPtr const & stateChangeRequester)
+{
+    this->stateChangeRequester = stateChangeRequester;
 }
 
 void PvaClientChannel::connect(double timeout)

--- a/src/pvaClientMonitor.cpp
+++ b/src/pvaClientMonitor.cpp
@@ -219,8 +219,17 @@ void PvaClientMonitor::monitorEvent(MonitorPtr const & monitor)
 void PvaClientMonitor::unlisten(MonitorPtr const & monitor)
 {
     if(PvaClient::getDebug()) cout << "PvaClientMonitor::unlisten\n";
-    throw std::runtime_error("pvaClientMonitor::unlisten called but do not know what to do");
+    PvaClientMonitorRequesterPtr req = pvaClientMonitorRequester.lock();
+    if(req) {
+        req->unlisten();
+        return;
+    }
+    string channelName("disconnected");
+    Channel::shared_pointer chan(channel.lock());
+    if(chan) channelName = chan->getChannelName();
+    cerr << channelName + "pvaClientMonitor::unlisten called but no PvaClientMonitorRequester\n";
 }
+
 
 void PvaClientMonitor::connect()
 {


### PR DESCRIPTION
1) added stateChangeRequester
2)  improve semantics for unlisten and channelStateChange

This also  fixes some problems associated with on-line delete.
These problems appeared when pvDatabaseCPP was changed to notify clients when
a PVRecord is deleted.

With the changes to pvDatabaseCPP and pvaClientCPP on-line delete now works!!