### PR TITLE
fix bug in pvaClientNTMultiData that can cause a crash

### DIFF
--- a/src/pvaClientNTMultiData.cpp
+++ b/src/pvaClientNTMultiData.cpp
@@ -145,7 +145,7 @@ void PvaClientNTMultiData::endDeltaTime()
         PVStructurePtr pvst = topPVStructure[i];
         if(!pvst) {
             unionValue[i] = PVUnionPtr();
-        } else {
+        } else if(unionValue[i]) {
             unionValue[i]->set(pvst->getSubField("value"));
             if(gotAlarm)
             {


### PR DESCRIPTION
This fixes a bug that can cause a crash when examplePvaClientNTMulti is executed.
This is one of the examples in exampleCPP/exampleClient