### PR TITLE
with multiple threads callback can occur before create completes

### DIFF
--- a/src/pvaClientChannel.cpp
+++ b/src/pvaClientChannel.cpp
@@ -170,6 +170,7 @@ void PvaClientChannel::channelCreated(const Status& status, Channel::shared_poin
            << endl;
     }
     Lock xx(mutex);
+    this->channel = channel;
     if(connectState==connected) return;
     if(connectState!=connectActive) {
          string message("PvaClientChannel::channelCreated");
@@ -201,11 +202,14 @@ void PvaClientChannel::channelStateChange(
     bool waitingForConnect = false;
     if(connectState==connectActive) waitingForConnect = true;
     if(connectionState!=Channel::CONNECTED) {
+        Lock xx(mutex);
         string mess(channelName +
                 " connection state " + Channel::ConnectionStateNames[connectionState]);
         message(mess,errorMessage);
         connectState = notConnected;
     } else {
+        Lock xx(mutex);
+        this->channel = channel;
         connectState = connected;
     }
     if(waitingForConnect) {


### PR DESCRIPTION
This is involved with pvAccessCPP issue #117 which was a failure when connecting to 50000 channels.
The pull request #131 in pvAccessCPP may also be involved.