### PR TITLE
address issue #54

### DIFF
--- a/src/pv/pvaClient.h
+++ b/src/pv/pvaClient.h
@@ -1813,6 +1813,7 @@ private:
 
     enum RPCState {rpcIdle,rpcActive,rpcComplete};
     RPCState rpcState;
+    epics::pvData::Status requestStatus;
     double responseTimeout;
     friend class RPCRequesterImpl;
 };


### PR DESCRIPTION
Changes are to pvaClientRPC.
It now throws RPCRequestException in two cases:
1) client calls PvaClientRPC::connect() and connection is not made
2) client calls PvaClientRPC::request(PVStructure::shared_pointer const & pvArgument) and it fails.