### PR TITLE
Cleanup whitespace

### DIFF
--- a/src/pv/pvaClient.h
+++ b/src/pv/pvaClient.h
@@ -1860,4 +1860,3 @@ private:
  * <a href = "../pvaClientCPP.html">pvaClientCPP.html</a>
  *
  */
-

--- a/src/pv/pvaClient.h
+++ b/src/pv/pvaClient.h
@@ -36,7 +36,7 @@
 
 #ifdef pvaClientEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef pvaClientEpicsExportSharedSymbols
+#   undef pvaClientEpicsExportSharedSymbols
 #endif
 
 #include <shareLib.h>

--- a/src/pv/pvaClient.h
+++ b/src/pv/pvaClient.h
@@ -18,7 +18,7 @@
 #include <list>
 #include <iostream>
 #include <ostream>
-#include <sstream>  
+#include <sstream>
 #include <pv/requester.h>
 #include <pv/status.h>
 #include <pv/event.h>
@@ -41,7 +41,7 @@
 
 #include <shareLib.h>
 
-namespace epics { namespace pvaClient { 
+namespace epics { namespace pvaClient {
 
 class PvaClient;
 typedef std::tr1::shared_ptr<PvaClient> PvaClientPtr;
@@ -161,7 +161,7 @@ public:
     PvaClientChannelPtr createChannel(
        std::string const & channelName,
        std::string const & providerName = "pva");
-    
+
     /** @brief Set a requester.
      *
      * The default is for PvaClient to handle messages by printing to System.out.
@@ -204,7 +204,7 @@ class PvaClientPutCache;
 typedef std::tr1::shared_ptr<PvaClientPutCache> PvaClientPutCachePtr;
 
 
-/** 
+/**
  * @brief A callback for change in connection status.
  *
  * <a href = "../htmldoxygen/pvaClientChannelStateChangeRequester.html">Overview of PvaClientChannelStateChangeRequester</a>
@@ -228,7 +228,7 @@ public:
     virtual void channelStateChange(PvaClientChannelPtr const & channel, bool isConnected) = 0;
 };
 
-/** 
+/**
  * @brief An easy to use alternative to directly calling the Channel methods of pvAccess.
  *
  * <a href = "../htmldoxygen/pvaClientChannel.html">Overview of PvaClientChannel</a>
@@ -245,7 +245,7 @@ public:
      */
     ~PvaClientChannel();
     /** @brief Set a client stateChangeRequester.
-     * 
+     *
      * @param stateChangeRequester The client stateChangeRequester implementation.
      */
     void setStateChangeRequester(PvaClientChannelStateChangeRequesterPtr const &stateChangeRequester);
@@ -290,7 +290,7 @@ public:
      * @throw runtime_error if failure.
      */
     PvaClientProcessPtr createProcess(std::string const & request = "");
-    /** Creates a PvaClientProcess. 
+    /** Creates a PvaClientProcess.
      *
      * @param pvRequest The syntax of pvRequest is defined by the copy facility of pvData.
      * @return The interface.
@@ -351,7 +351,7 @@ public:
     epics::pvData::shared_vector<const std::string>  getStringArray(
         std::string const & request = "field(value)");
     /** @brief create a PvaClientPut.
-     * 
+     *
      * Get a cached PvaClientPut or create and connect to a new PvaClientPut.
      * Then call it's get method.
      * @param request The syntax of request is defined by the copy facility of pvData.
@@ -397,7 +397,7 @@ public:
         epics::pvData::shared_vector<const double> const & value,
         std::string const & request = "field(value)");
     /** @brief Copy array to the value field.
-     * 
+     *
      * @param value The new value.
      * @param request The syntax of request is defined by the copy facility of pvData.
      * @throw runtime_error if failure.
@@ -450,7 +450,7 @@ public:
      * @throw runtime_error if failure.
      */
     PvaClientMonitorPtr monitor(std::string const & request = "field(value,alarm,timeStamp)");
-    /** @brief Call the next method with request =  "field(value,alarm,timeStamp)" 
+    /** @brief Call the next method with request =  "field(value,alarm,timeStamp)"
       *
       * @param pvaClientMonitorRequester The client callback.
       * @return The interface.
@@ -539,7 +539,7 @@ private:
     std::string channelName;
     std::string providerName;
     ConnectState connectState;
-    
+
     epics::pvData::CreateRequest::shared_pointer createRequest;
     PvaClientGetCachePtr pvaClientGetCache;
     PvaClientPutCachePtr pvaClientPutCache;
@@ -561,7 +561,7 @@ public:
     friend class PvaClient;
 };
 
-/** 
+/**
  *  @brief A base class for PvaClientGetData, PvaClientPutData, and PvaClientMonitorData.
  *
  * <a href = "../htmldoxygen/pvaClientData.html">Overview of PvaClientData</a>
@@ -737,7 +737,7 @@ private:
     friend class PvaClientPutGet;
 };
 
-/** 
+/**
  *  @brief A class that holds data returned by PvaClientGet or PvaClientPutGet
  *
  * <a href = "../htmldoxygen/pvaClientGetData.html">Overview of PvaClientGetData</a>
@@ -764,7 +764,7 @@ private:
 };
 
 class PvaClientPostHandlerPvt; // private to PvaClientPutData
-/** 
+/**
  *  @brief A class that holds data given to  by PvaClientPut or PvaClientPutGet
  *
  * <a href = "../htmldoxygen/pvaClientPutData.html">Overview of PvaClientPutData</a>
@@ -775,7 +775,7 @@ public:
     POINTER_DEFINITIONS(PvaClientPutData);
     /**
      * @brief Destructor
-     */    
+     */
     ~PvaClientPutData() {}
     /** @brief Put the value as a double.
      * @param value The new value.
@@ -828,7 +828,7 @@ public:
     POINTER_DEFINITIONS(PvaClientMonitorData);
     /**
      * @brief Destructor
-     */    
+     */
     ~PvaClientMonitorData() {}
     /** @brief Get the overrun BitSet for the pvStructure
      * This shows which fields have had more than one change.
@@ -914,7 +914,7 @@ public:
         PvaClientChannelPtr const & pvaClientChannel,
         epics::pvData::PVStructurePtr const &pvRequest
     );
-    
+
     /** @brief Destructor
      */
     ~PvaClientProcess();
@@ -968,7 +968,7 @@ private:
         PvaClientPtr const &pvaClient,
         PvaClientChannelPtr const & pvaClientChannel,
         epics::pvData::PVStructurePtr const &pvRequest);
-    
+
     void checkProcessState();
     enum ProcessConnectState {connectIdle,connectActive,connected};
 
@@ -1279,7 +1279,7 @@ private :
         PvaClientPtr const &pvaClient,
         PvaClientChannelPtr const & pvaClientChannel,
         epics::pvData::PVStructurePtr const &pvRequest);
-    
+
     void checkConnectState();
     enum PutConnectState {connectIdle,connectActive,connected};
 
@@ -1357,11 +1357,11 @@ public:
         PvaClientPutGetPtr const & clientPutGet)
     {
     }
-    
+
 };
 
 
-/** 
+/**
  * @brief An easy to use alternative to ChannelPutGet.
  *
  * <a href = "../htmldoxygen/pvaClientPutGet.html">Overview of PvaClientPutGet</a>
@@ -1448,11 +1448,11 @@ public:
     /** @brief Get the put data.
      * @return The interface.
      */
-    PvaClientPutDataPtr getPutData();   
+    PvaClientPutDataPtr getPutData();
     /** @brief Get the get data.
      * @return The interface.
      */
-    PvaClientGetDataPtr getGetData(); 
+    PvaClientGetDataPtr getGetData();
     /** @brief Get the PvaClientChannel;
      *
      * @return The interface.
@@ -1593,7 +1593,7 @@ public:
         std::string const & request,
         PvaClientChannelStateChangeRequesterPtr const & stateChangeRequester
             = PvaClientChannelStateChangeRequesterPtr(),
-        PvaClientMonitorRequesterPtr const & monitorRequester 
+        PvaClientMonitorRequesterPtr const & monitorRequester
             = PvaClientMonitorRequesterPtr()
     ) EPICS_DEPRECATED;
     /** @brief Destructor
@@ -1656,7 +1656,7 @@ public:
      *
      * @return The interface.
      */
-    PvaClientMonitorDataPtr getData();   
+    PvaClientMonitorDataPtr getData();
 private:
     std::string getRequesterName();
     void message(std::string const & message,epics::pvData::MessageType messageType);
@@ -1687,7 +1687,7 @@ private:
     epics::pvData::Status monitorConnectStatus;
     epics::pvData::MonitorPtr monitor;
     epics::pvData::MonitorElementPtr monitorElement;
-    
+
     PvaClientMonitorRequesterWPtr pvaClientMonitorRequester;
     MonitorConnectState connectState;
     bool userPoll;
@@ -1764,7 +1764,7 @@ public:
      * @brief Set a timeout for a request.
      * @param responseTimeout The time in seconds to wait for a request to complete.
      */
-    void setResponseTimeout(double responseTimeout) 
+    void setResponseTimeout(double responseTimeout)
     {
         this->responseTimeout = responseTimeout;
     }
@@ -1834,12 +1834,12 @@ private:
     PvaClient::weak_pointer pvaClient;
     epics::pvAccess::Channel::weak_pointer channel;
     epics::pvData::PVStructurePtr pvRequest;
-    
+
     epics::pvData::Mutex mutex;
     epics::pvData::Event waitForConnect;
     epics::pvData::Event waitForDone;
 
-    PvaClientRPCRequesterWPtr pvaClientRPCRequester;    
+    PvaClientRPCRequesterWPtr pvaClientRPCRequester;
     RPCRequesterImplPtr rpcRequester;
     epics::pvAccess::ChannelRPC::shared_pointer channelRPC;
     epics::pvData::PVStructurePtr pvResponse;
@@ -1858,6 +1858,6 @@ private:
 /** @page Overview Documentation
  *
  * <a href = "../pvaClientCPP.html">pvaClientCPP.html</a>
- *  
+ *
  */
 

--- a/src/pv/pvaClientMultiChannel.h
+++ b/src/pv/pvaClientMultiChannel.h
@@ -615,4 +615,3 @@ private:
 }}
 
 #endif  /* PVACLIENTMULTICHANNEL_H */
-

--- a/src/pv/pvaClientMultiChannel.h
+++ b/src/pv/pvaClientMultiChannel.h
@@ -21,7 +21,7 @@
 
 #ifdef pvaClientMultiChannelEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef pvaClientMultiChannelEpicsExportSharedSymbols
+#   undef pvaClientMultiChannelEpicsExportSharedSymbols
 #endif
 
 

--- a/src/pv/pvaClientMultiChannel.h
+++ b/src/pv/pvaClientMultiChannel.h
@@ -28,7 +28,7 @@
 #include <pv/pvaClient.h>
 
 
-namespace epics { namespace pvaClient { 
+namespace epics { namespace pvaClient {
 
 
 class PvaClientMultiChannel;
@@ -115,7 +115,7 @@ public:
      * @brief create a pvaClientMultiGetDouble
      * @return The interface.
      */
-    PvaClientMultiGetDoublePtr createGet();   
+    PvaClientMultiGetDoublePtr createGet();
     /**
      * @brief Create a pvaClientMultiPutDouble.
      * @return The interface.
@@ -152,7 +152,7 @@ private:
         std::string const & providerName,
         size_t maxNotConnected);
     void checkConnected();
-    
+
     PvaClientPtr pvaClient;
     epics::pvData::shared_vector<const std::string> channelName;
     std::string providerName;
@@ -176,7 +176,7 @@ class epicsShareClass PvaClientMultiGetDouble :
 
 public:
     POINTER_DEFINITIONS(PvaClientMultiGetDouble);
-    
+
     /**
      * @brief Create a PvaClientMultiGetDouble.
      * @param pvaClientMultiChannel The interface to PvaClientMultiChannel.
@@ -214,7 +214,7 @@ private:
     PvaClientChannelArray pvaClientChannelArray;
     size_t nchannel;
     epics::pvData::Mutex mutex;
-    
+
     epics::pvData::shared_vector<double> doubleValue;
     std::vector<PvaClientGetPtr> pvaClientGet;
     bool isGetConnected;
@@ -229,7 +229,7 @@ class epicsShareClass PvaClientMultiPutDouble :
 
 public:
     POINTER_DEFINITIONS(PvaClientMultiPutDouble);
-   
+
     /** @brief Create a PvaClientMultiPutDouble.
      * @param pvaClientMultiChannel The interface to PvaClientMultiChannel.
      * @param pvaClientChannelArray The PvaClientChannel array.
@@ -277,7 +277,7 @@ class epicsShareClass PvaClientMultiMonitorDouble :
 
 public:
     POINTER_DEFINITIONS(PvaClientMultiMonitorDouble);
-    
+
     /** @brief Create a PvaClientMultiMonitorDouble.
      * @param pvaClientMultiChannel The interface to PvaClientMultiChannel.
      * @param pvaClientChannelArray The PvaClientChannel array.
@@ -388,8 +388,8 @@ private:
     epics::pvData::PVStructurePtr pvRequest;
     size_t nchannel;
     epics::pvData::Mutex mutex;
-    
-    
+
+
     PvaClientNTMultiDataPtr pvaClientNTMultiData;
     std::vector<PvaClientGetPtr> pvaClientGet;
     bool isConnected;
@@ -413,7 +413,7 @@ public:
     static PvaClientNTMultiPutPtr create(
          PvaClientMultiChannelPtr const &pvaClientMultiChannel,
          PvaClientChannelArray const &pvaClientChannelArray);
-     
+
     ~PvaClientNTMultiPut();
      /**
      * @brief Connect a channelPut for each channel.
@@ -543,15 +543,15 @@ public:
          PvaClientChannelArray const &pvaClientChannelArray,
          epics::pvData::PVStructurePtr const &  pvRequest);
     ~PvaClientNTMultiData();
-    
+
     /**
      * @brief Get the number of channels.
      * @return The number of channels.
      */
     size_t getNumber();
-   
+
     /**
-     * @brief Set the timeStamp base for computing deltaTimes. 
+     * @brief Set the timeStamp base for computing deltaTimes.
      */
     void startDeltaTime();
     /**
@@ -564,7 +564,7 @@ public:
      * @brief Get the time when the last get was made.
      * @return The timeStamp.
      */
-    epics::pvData::TimeStamp getTimeStamp(); 
+    epics::pvData::TimeStamp getTimeStamp();
     /**
      * @brief Get the  NTMultiChannel.
      * @return The value.
@@ -594,7 +594,7 @@ private:
     std::vector<epics::pvData::PVStructurePtr> topPVStructure;
     bool gotAlarm;
     bool gotTimeStamp;
-    
+
     epics::pvData::StructureConstPtr ntMultiChannelStructure;
     epics::pvData::shared_vector<epics::pvData::PVUnionPtr> unionValue;
     epics::pvData::shared_vector<epics::pvData::int32> severity;

--- a/src/pvaClient.cpp
+++ b/src/pvaClient.cpp
@@ -23,7 +23,7 @@ using namespace epics::pvAccess;
 using namespace epics::pvAccess::ca;
 using namespace std;
 
-namespace epics { namespace pvaClient { 
+namespace epics { namespace pvaClient {
 
 
 class epicsShareClass PvaClientChannelCache
@@ -42,7 +42,7 @@ public:
 private:
     map<string,PvaClientChannelPtr> pvaClientChannelMap;
 };
-   
+
 PvaClientChannelPtr PvaClientChannelCache::getChannel(
     string const & channelName,
     string const & providerName)
@@ -77,7 +77,7 @@ void PvaClientChannelCache::showCache()
          string providerName = channel->getProvider()->getProviderName();
          cout << "channel " << channelName << " provider " << providerName << endl;
          pvaChannel->showCache();
-    } 
+    }
 }
 
 size_t PvaClientChannelCache::cacheSize()
@@ -137,7 +137,7 @@ PvaClient::PvaClient(std::string const & providerNames)
               }
              CAClientFactory::start();
              caStarted = true;
-         } else { 
+         } else {
              if(!channelRegistry->getProvider(providerName)) {
                  cerr << "PvaClient::get provider " << providerName  << " not known" << endl;
              }
@@ -191,7 +191,7 @@ PvaClientChannelPtr PvaClient::channel(
         std::string const & providerName,
         double timeOut)
 {
-    PvaClientChannelPtr pvaClientChannel = 
+    PvaClientChannelPtr pvaClientChannel =
         pvaClientChannelCache->getChannel(channelName,providerName);
     if(pvaClientChannel) return pvaClientChannel;
     pvaClientChannel = createChannel(channelName,providerName);
@@ -231,4 +231,4 @@ size_t PvaClient::cacheSize()
 }
 
 }}
- 
+

--- a/src/pvaClient.cpp
+++ b/src/pvaClient.cpp
@@ -231,4 +231,3 @@ size_t PvaClient::cacheSize()
 }
 
 }}
-

--- a/src/pvaClientChannel.cpp
+++ b/src/pvaClientChannel.cpp
@@ -183,7 +183,7 @@ void PvaClientChannel::channelCreated(const Status& status, Channel::shared_poin
         throw std::runtime_error(message);
     }
     if(channel->isConnected()) {
-        connectState = connected; 
+        connectState = connected;
         waitForConnect.signal();
     }
 }
@@ -267,7 +267,7 @@ void PvaClientChannel::connect(double timeout)
     Status status = waitConnect(timeout);
     if(status.isOK()) return;
     if(PvaClient::getDebug()) cout << "PvaClientChannel::connect  waitConnect failed\n";
-    string message = string("channel ") + channelName 
+    string message = string("channel ") + channelName
                     + " PvaClientChannel::connect " + status.getMessage();
     throw std::runtime_error(message);
 }
@@ -330,7 +330,7 @@ PvaClientProcessPtr PvaClientChannel::createProcess(string const & request)
 {
     PVStructurePtr pvRequest = createRequest->createRequest(request);
     if(!pvRequest) {
-        string message = string("channel ") + channelName 
+        string message = string("channel ") + channelName
             + " PvaClientChannel::createProcess invalid pvRequest: "
             + createRequest->getMessage();
         throw std::runtime_error(message);
@@ -364,7 +364,7 @@ PvaClientGetPtr PvaClientChannel::createGet(string const & request)
 {
     PVStructurePtr pvRequest = createRequest->createRequest(request);
     if(!pvRequest) {
-        string message = string("channel ") + channelName 
+        string message = string("channel ") + channelName
             + " PvaClientChannel::createGet invalid pvRequest: "
             + createRequest->getMessage();
         throw std::runtime_error(message);
@@ -419,7 +419,7 @@ PvaClientPutPtr PvaClientChannel::createPut(string const & request)
 {
     PVStructurePtr pvRequest = createRequest->createRequest(request);
     if(!pvRequest) {
-        string message = string("channel ") + channelName 
+        string message = string("channel ") + channelName
             + " PvaClientChannel::createPut invalid pvRequest: "
             + createRequest->getMessage();
         throw std::runtime_error(message);
@@ -477,7 +477,7 @@ PvaClientPutGetPtr PvaClientChannel::createPutGet(string const & request)
 {
     PVStructurePtr pvRequest = createRequest->createRequest(request);
     if(!pvRequest) {
-        string message = string("channel ") + channelName 
+        string message = string("channel ") + channelName
             + " PvaClientChannel::createPutGet invalid pvRequest: "
             + createRequest->getMessage();
         throw std::runtime_error(message);
@@ -499,7 +499,7 @@ PvaClientArrayPtr PvaClientChannel::createArray(string const & request)
 {
     PVStructurePtr pvRequest = createRequest->createRequest(request);
     if(!pvRequest) {
-        string message = string("channel ") + channelName 
+        string message = string("channel ") + channelName
             + " PvaClientChannel::createArray invalid pvRequest: "
             + createRequest->getMessage();
         throw std::runtime_error(message);
@@ -541,7 +541,7 @@ PvaClientMonitorPtr PvaClientChannel::createMonitor(string const & request)
 {
     PVStructurePtr pvRequest = createRequest->createRequest(request);
     if(!pvRequest) {
-        string message = string("channel ") + channelName 
+        string message = string("channel ") + channelName
             + " PvaClientChannel::createMonitor invalid pvRequest: "
             + createRequest->getMessage();
         throw std::runtime_error(message);
@@ -561,7 +561,7 @@ PVStructurePtr PvaClientChannel::rpc(
     PVStructurePtr const &  pvRequest,
     PVStructurePtr const & pvArgument)
 {
-    
+
     PvaClientRPCPtr rpc = createRPC(pvRequest);
     return rpc->request(pvArgument);
 }

--- a/src/pvaClientData.cpp
+++ b/src/pvaClientData.cpp
@@ -363,7 +363,7 @@ void PvaClientData::parse(const std::vector<std::string> &args)
         if(field.size()==std::string::npos) {
            parse(rest,pvStructure,bitSet);
            continue;
-        } 
+        }
         PVFieldPtr pvField(pvStructure->getSubField(field));
         if(!pvField) throw std::runtime_error(messagePrefix + field +" does not exist");
         // look for enumerated structure
@@ -428,7 +428,7 @@ const PVFieldPtrArray pvFields(pvStructure->getPVFields());
             {
                 PVStructurePtr pvStructure = static_pointer_cast<PVStructure>(pvField);
                 zeroArrayLength(pvStructure);
-            } 
+            }
             break;
         default:
                break;

--- a/src/pvaClientGet.cpp
+++ b/src/pvaClientGet.cpp
@@ -55,7 +55,7 @@ public:
     {
         PvaClientGetPtr clientGet(pvaClientGet.lock());
         if(!clientGet) return;
-        clientGet->channelGetConnect(status,channelGet,structure);  
+        clientGet->channelGetConnect(status,channelGet,structure);
     }
 
     virtual void getDone(
@@ -182,7 +182,7 @@ void PvaClientGet::channelGetConnect(
           req->channelGetConnect(status,shared_from_this());
     }
     waitForConnect.signal();
-    
+
 }
 
 void PvaClientGet::getDone(

--- a/src/pvaClientMonitor.cpp
+++ b/src/pvaClientMonitor.cpp
@@ -57,21 +57,21 @@ public:
     {
         PvaClientMonitorPtr clientMonitor(pvaClientMonitor.lock());
         if(!clientMonitor) return;
-        clientMonitor->monitorConnect(status,monitor,structure);  
+        clientMonitor->monitorConnect(status,monitor,structure);
     }
 
     virtual void unlisten(epics::pvData::MonitorPtr const & monitor)
     {
         PvaClientMonitorPtr clientMonitor(pvaClientMonitor.lock());
         if(!clientMonitor) return;
-        clientMonitor->unlisten(monitor);  
+        clientMonitor->unlisten(monitor);
     }
 
     virtual void monitorEvent(epics::pvData::MonitorPtr const & monitor)
     {
         PvaClientMonitorPtr clientMonitor(pvaClientMonitor.lock());
         if(!clientMonitor) return;
-        clientMonitor->monitorEvent(monitor);  
+        clientMonitor->monitorEvent(monitor);
     }
 };
 
@@ -131,7 +131,7 @@ PvaClientMonitor::PvaClientMonitor(
 {
     if(PvaClient::getDebug()) {
          cout<< "PvaClientMonitor::PvaClientMonitor\n"
-             << " channelName " << pvaClientChannel->getChannel()->getChannelName() 
+             << " channelName " << pvaClientChannel->getChannel()->getChannelName()
              << endl;
     }
 }
@@ -276,7 +276,7 @@ void PvaClientMonitor::monitorEvent(MonitorPtr const & monitor)
         cout << "PvaClientMonitor::monitorEvent"
            << " channelName " << pvaClientChannel->getChannel()->getChannelName()
            << endl;
-    }    
+    }
     PvaClientMonitorRequesterPtr req = pvaClientMonitorRequester.lock();
     if(req) req->event(shared_from_this());
     if(userWait) waitForEvent.signal();
@@ -300,7 +300,7 @@ void PvaClientMonitor::connect()
     issueConnect();
     Status status = waitConnect();
     if(status.isOK()) return;
-    string message = string("channel ") 
+    string message = string("channel ")
         + pvaClientChannel->getChannel()->getChannelName()
         + " PvaClientMonitor::connect "
         + status.getMessage();

--- a/src/pvaClientMultiChannel.cpp
+++ b/src/pvaClientMultiChannel.cpp
@@ -140,7 +140,7 @@ PvaClientPtr PvaClientMultiChannel::getPvaClient()
     return pvaClient;
 }
 
- 
+
 
 PvaClientMultiGetDoublePtr PvaClientMultiChannel::createGet()
 {

--- a/src/pvaClientMultiChannel.cpp
+++ b/src/pvaClientMultiChannel.cpp
@@ -80,7 +80,7 @@ Status PvaClientMultiChannel::connect(double timeout)
     Status status = Status::Ok;
     size_t numBad = 0;
     for(size_t i=0; i< numChannel; ++i) {
-	if(numBad==0) {
+        if(numBad==0) {
             status = pvaClientChannelArray[i]->waitConnect(timeout);
         } else {
             status = pvaClientChannelArray[i]->waitConnect(.001);

--- a/src/pvaClientMultiGetDouble.cpp
+++ b/src/pvaClientMultiGetDouble.cpp
@@ -21,7 +21,7 @@ using namespace epics::pvAccess;
 using namespace epics::nt;
 using namespace std;
 
-namespace epics { namespace pvaClient { 
+namespace epics { namespace pvaClient {
 
 
 PvaClientMultiGetDoublePtr PvaClientMultiGetDouble::create(
@@ -79,7 +79,7 @@ epics::pvData::shared_vector<double> PvaClientMultiGetDouble::get()
 {
     if(!isGetConnected) connect();
     shared_vector<epics::pvData::boolean> isConnected = pvaClientMultiChannel->getIsConnected();
-    
+
     for(size_t i=0; i<nchannel; ++i)
     {
          if(isConnected[i]) {
@@ -96,7 +96,7 @@ epics::pvData::shared_vector<double> PvaClientMultiGetDouble::get()
                throw std::runtime_error(message);
          }
     }
-    
+
     for(size_t i=0; i<nchannel; ++i)
     {
         if(isConnected[i])

--- a/src/pvaClientMultiMonitorDouble.cpp
+++ b/src/pvaClientMultiMonitorDouble.cpp
@@ -21,7 +21,7 @@ using namespace epics::pvAccess;
 using namespace epics::nt;
 using namespace std;
 
-namespace epics { namespace pvaClient { 
+namespace epics { namespace pvaClient {
 
 
 PvaClientMultiMonitorDoublePtr PvaClientMultiMonitorDouble::create(

--- a/src/pvaClientMultiPutDouble.cpp
+++ b/src/pvaClientMultiPutDouble.cpp
@@ -21,7 +21,7 @@ using namespace epics::pvAccess;
 using namespace epics::nt;
 using namespace std;
 
-namespace epics { namespace pvaClient { 
+namespace epics { namespace pvaClient {
 
 
 PvaClientMultiPutDoublePtr PvaClientMultiPutDouble::create(

--- a/src/pvaClientNTMultiData.cpp
+++ b/src/pvaClientNTMultiData.cpp
@@ -20,7 +20,7 @@ using namespace epics::pvAccess;
 using namespace epics::nt;
 using namespace std;
 
-namespace epics { namespace pvaClient { 
+namespace epics { namespace pvaClient {
 
 PvaClientNTMultiDataPtr PvaClientNTMultiData::create(
     epics::pvData::UnionConstPtr const & u,
@@ -63,7 +63,7 @@ PvaClientNTMultiData::PvaClientNTMultiData(
          severity.resize(nchannel);
          status.resize(nchannel);
          message.resize(nchannel);
-         
+
     }
     if(pvRequest->getSubField("field.timeStamp")) {
         gotTimeStamp = true;
@@ -165,7 +165,7 @@ void PvaClientNTMultiData::endDeltaTime(bool valueOnly)
                     userTag[i] = pvTag->get();
                 }
             }
-        } 
+        }
     }
 }
 

--- a/src/pvaClientNTMultiGet.cpp
+++ b/src/pvaClientNTMultiGet.cpp
@@ -20,7 +20,7 @@ using namespace epics::pvAccess;
 using namespace epics::nt;
 using namespace std;
 
-namespace epics { namespace pvaClient { 
+namespace epics { namespace pvaClient {
 
 
 PvaClientNTMultiGetPtr PvaClientNTMultiGet::create(
@@ -75,7 +75,7 @@ void PvaClientNTMultiGet::connect()
          if(isConnected[i]) {
                Status status = pvaClientGet[i]->waitConnect();
                if(status.isOK()) continue;
-               string message = string("channel ") +pvaClientChannelArray[i]->getChannelName() 
+               string message = string("channel ") +pvaClientChannelArray[i]->getChannelName()
                     + " PvaChannelGet::waitConnect " + status.getMessage();
                throw std::runtime_error(message);
          }
@@ -87,7 +87,7 @@ void PvaClientNTMultiGet::get(bool valueOnly)
 {
     if(!isConnected) connect();
     shared_vector<epics::pvData::boolean> isConnected = pvaClientMultiChannel->getIsConnected();
-    
+
     for(size_t i=0; i<nchannel; ++i)
     {
          if(isConnected[i]) {
@@ -99,7 +99,7 @@ void PvaClientNTMultiGet::get(bool valueOnly)
          if(isConnected[i]) {
                Status status = pvaClientGet[i]->waitGet();
                if(status.isOK()) continue;
-               string message = string("channel ") +pvaClientChannelArray[i]->getChannelName() 
+               string message = string("channel ") +pvaClientChannelArray[i]->getChannelName()
                     + " PvaChannelGet::waitGet " + status.getMessage();
                throw std::runtime_error(message);
          }

--- a/src/pvaClientNTMultiMonitor.cpp
+++ b/src/pvaClientNTMultiMonitor.cpp
@@ -23,7 +23,7 @@ using namespace epics::pvAccess;
 using namespace epics::nt;
 using namespace std;
 
-namespace epics { namespace pvaClient { 
+namespace epics { namespace pvaClient {
 
 PvaClientNTMultiMonitorPtr PvaClientNTMultiMonitor::create(
     PvaClientMultiChannelPtr const &pvaMultiChannel,
@@ -79,7 +79,7 @@ void PvaClientNTMultiMonitor::connect()
          if(isConnected[i]) {
                Status status = pvaClientMonitor[i]->waitConnect();
                if(status.isOK()) continue;
-               string message = string("channel ") +pvaClientChannelArray[i]->getChannelName() 
+               string message = string("channel ") +pvaClientChannelArray[i]->getChannelName()
                     + " PvaChannelMonitor::waitConnect " + status.getMessage();
                throw std::runtime_error(message);
          }

--- a/src/pvaClientNTMultiPut.cpp
+++ b/src/pvaClientNTMultiPut.cpp
@@ -22,7 +22,7 @@ using namespace epics::pvAccess;
 using namespace epics::nt;
 using namespace std;
 
-namespace epics { namespace pvaClient { 
+namespace epics { namespace pvaClient {
 
 PvaClientNTMultiPutPtr PvaClientNTMultiPut::create(
     PvaClientMultiChannelPtr const &pvaMultiChannel,
@@ -67,7 +67,7 @@ void PvaClientNTMultiPut::connect()
          if(isConnected[i]) {
                Status status = pvaClientPut[i]->waitConnect();
                if(status.isOK()) continue;
-               string message = string("channel ") +pvaClientChannelArray[i]->getChannelName() 
+               string message = string("channel ") +pvaClientChannelArray[i]->getChannelName()
                     + " PvaChannelPut::waitConnect " + status.getMessage();
                throw std::runtime_error(message);
          }
@@ -83,7 +83,7 @@ void PvaClientNTMultiPut::connect()
          if(isConnected[i]) {
                Status status = pvaClientPut[i]->waitGet();
                if(status.isOK()) continue;
-               string message = string("channel ") +pvaClientChannelArray[i]->getChannelName() 
+               string message = string("channel ") +pvaClientChannelArray[i]->getChannelName()
                     + " PvaChannelPut::waitGet " + status.getMessage();
                throw std::runtime_error(message);
          }
@@ -121,9 +121,9 @@ void PvaClientNTMultiPut::put()
          if(isConnected[i]) {
               Status status = pvaClientPut[i]->waitPut();
               if(status.isOK())  continue;
-              string message = string("channel ") +pvaClientChannelArray[i]->getChannelName() 
+              string message = string("channel ") +pvaClientChannelArray[i]->getChannelName()
                     + " PvaChannelPut::waitPut " + status.getMessage();
-              throw std::runtime_error(message); 
+              throw std::runtime_error(message);
          }
     }
 }

--- a/src/pvaClientProcess.cpp
+++ b/src/pvaClientProcess.cpp
@@ -54,7 +54,7 @@ public:
     {
         PvaClientProcessPtr clientProcess(pvaClientProcess.lock());
         if(!clientProcess) return;
-        clientProcess->channelProcessConnect(status,channelProcess);  
+        clientProcess->channelProcessConnect(status,channelProcess);
     }
 
     virtual void processDone(
@@ -156,7 +156,7 @@ void PvaClientProcess::channelProcessConnect(
           req->channelProcessConnect(status,shared_from_this());
     }
     waitForConnect.signal();
-    
+
 }
 
 void PvaClientProcess::processDone(
@@ -174,7 +174,7 @@ void PvaClientProcess::processDone(
         channelProcessStatus = status;
         processState = processComplete;
     }
-    
+
     PvaClientProcessRequesterPtr  req(pvaClientProcessRequester.lock());
     if(req) {
           req->processDone(status,shared_from_this());

--- a/src/pvaClientPut.cpp
+++ b/src/pvaClientPut.cpp
@@ -55,7 +55,7 @@ public:
     {
         PvaClientPutPtr clientPut(pvaClientPut.lock());
         if(!clientPut) return;
-        clientPut->channelPutConnect(status,channelPut,structure);  
+        clientPut->channelPutConnect(status,channelPut,structure);
     }
 
     virtual void getDone(
@@ -183,7 +183,7 @@ void PvaClientPut::channelPutConnect(
           req->channelPutConnect(status,shared_from_this());
     }
     waitForConnect.signal();
-    
+
 }
 
 void PvaClientPut::getDone(
@@ -249,7 +249,7 @@ void PvaClientPut::connect()
     issueConnect();
     Status status = waitConnect();
     if(status.isOK()) return;
-    string message = string("channel ") 
+    string message = string("channel ")
         + pvaClientChannel->getChannel()->getChannelName()
         + " PvaClientPut::connect "
         + status.getMessage();
@@ -271,7 +271,7 @@ void PvaClientPut::issueConnect()
     connectState = connectActive;
     channelPutConnectStatus = Status(Status::STATUSTYPE_ERROR, "connect active");
     channelPut = pvaClientChannel->getChannel()->createChannelPut(channelPutRequester,pvRequest);
-       
+
 }
 
 Status PvaClientPut::waitConnect()
@@ -308,7 +308,7 @@ void PvaClientPut::get()
     issueGet();
     Status status = waitGet();
     if(status.isOK()) return;
-    string message = string("channel ") 
+    string message = string("channel ")
         +  pvaClientChannel->getChannel()->getChannelName()
         + " PvaClientPut::get "
         + status.getMessage();
@@ -376,7 +376,7 @@ void PvaClientPut::issuePut()
     if(PvaClient::getDebug()) {
         cout << "PvaClientPut::issuePut"
            << " channelName " << pvaClientChannel->getChannel()->getChannelName()
-           << " pvStructure\n" << pvaClientData->getPVStructure() 
+           << " pvStructure\n" << pvaClientData->getPVStructure()
            << " bitSet " << *pvaClientData->getChangedBitSet() << endl
            << endl;
     }

--- a/src/pvaClientPutGet.cpp
+++ b/src/pvaClientPutGet.cpp
@@ -55,7 +55,7 @@ public:
     {
         PvaClientPutGetPtr clientPutGet(pvaClientPutGet.lock());
         if(!clientPutGet) return;
-        clientPutGet->channelPutGetConnect(status,channelPutGet,putStructure,getStructure);  
+        clientPutGet->channelPutGetConnect(status,channelPutGet,putStructure,getStructure);
     }
 
     virtual void putGetDone(
@@ -173,7 +173,7 @@ void PvaClientPutGet::channelPutGetConnect(
            << " channelName " << pvaClientChannel->getChannel()->getChannelName()
            << " status.isOK " << (status.isOK() ? "true" : "false")
            << endl;
-    } 
+    }
     {
         Lock xx(mutex);
         this->channelPutGet = channelPutGet;
@@ -184,7 +184,7 @@ void PvaClientPutGet::channelPutGetConnect(
             pvaClientPutData->setMessagePrefix(channelPutGet->getChannel()->getChannelName());
             pvaClientGetData = PvaClientGetData::create(getStructure);
             pvaClientGetData->setMessagePrefix(channelPutGet->getChannel()->getChannelName());
-           
+
         } else {
              stringstream ss;
              ss << pvRequest;
@@ -199,7 +199,7 @@ void PvaClientPutGet::channelPutGetConnect(
           req->channelPutGetConnect(status,shared_from_this());
     }
     waitForConnect.signal();
-    
+
 }
 
 void PvaClientPutGet::putGetDone(
@@ -297,7 +297,7 @@ void PvaClientPutGet::connect()
     issueConnect();
     Status status = waitConnect();
     if(status.isOK()) return;
-    string message = string("channel ") 
+    string message = string("channel ")
         + pvaClientChannel->getChannel()->getChannelName()
         + " PvaClientPutGet::connect "
         + status.getMessage();
@@ -358,7 +358,7 @@ void PvaClientPutGet::putGet()
     issuePutGet();
     Status status = waitPutGet();
     if(status.isOK()) return;
-    string message = string("channel ") 
+    string message = string("channel ")
         + pvaClientChannel->getChannel()->getChannelName()
         + " PvaClientPut::putGet "
         + status.getMessage();
@@ -413,7 +413,7 @@ void PvaClientPutGet::getGet()
     issueGetGet();
     Status status = waitGetGet();
     if(status.isOK()) return;
-    string message = string("channel ") 
+    string message = string("channel ")
         + pvaClientChannel->getChannel()->getChannelName()
         + " PvaClientPut::getGet "
         + status.getMessage();
@@ -466,7 +466,7 @@ void PvaClientPutGet::getPut()
     issueGetPut();
     Status status = waitGetPut();
     if(status.isOK()) return;
-    string message = string("channel ") 
+    string message = string("channel ")
         + pvaClientChannel->getChannel()->getChannelName()
         + " PvaClientPut::getPut "
         + status.getMessage();

--- a/src/pvaClientRPC.cpp
+++ b/src/pvaClientRPC.cpp
@@ -94,7 +94,7 @@ PvaClientRPC::PvaClientRPC(
         PvaClientPtr const &pvaClient,
         Channel::shared_pointer const & channel,
         PVStructurePtr const &pvRequest)
-: 
+:
   connectState(connectIdle),
   pvaClient(pvaClient),
   channel(channel),
@@ -104,7 +104,7 @@ PvaClientRPC::PvaClientRPC(
 {
     if(PvaClient::getDebug()) {
          cout<< "PvaClientRPC::PvaClientRPC()"
-             << " channelName " << channel->getChannelName() 
+             << " channelName " << channel->getChannelName()
              << endl;
     }
 }
@@ -170,7 +170,7 @@ void PvaClientRPC::rpcConnect(
          cout << "PvaClientRPC::rpcConnect calling waitForConnect.signal\n";
     }
     waitForConnect.signal();
-    
+
 }
 
 void PvaClientRPC::requestDone(
@@ -195,7 +195,7 @@ void PvaClientRPC::requestDone(
              Channel::shared_pointer chan(channel.lock());
              if(chan) channelName = chan->getChannelName();
              string message = "channel "
-                 + channelName 
+                 + channelName
                  +" PvaClientRPC::requestDone"
                  + " but not active";
              throw std::runtime_error(message);
@@ -222,7 +222,7 @@ void PvaClientRPC::connect()
     Channel::shared_pointer chan(channel.lock());
     string channelName("disconnected");
     if(chan) channelName = chan->getChannelName();
-    string message = string("channel ") 
+    string message = string("channel ")
         + channelName
         + " PvaClientRPC::connect "
         + status.getMessage();
@@ -237,7 +237,7 @@ void PvaClientRPC::issueConnect()
         string channelName("disconnected");
         if(chan) channelName = chan->getChannelName();
         string message = string("channel ")
-            + channelName 
+            + channelName
             + " pvaClientRPC already connected ";
         throw std::runtime_error(message);
     }
@@ -326,7 +326,7 @@ void PvaClientRPC::request(
     PVStructure::shared_pointer const & pvArgument,
     PvaClientRPCRequesterPtr const & pvaClientRPCRequester)
 {
-    checkRPCState();   
+    checkRPCState();
     this->pvaClientRPCRequester = pvaClientRPCRequester;
     if(responseTimeout<=0.0) {
          {


### PR DESCRIPTION
This is purely cosmetic:
1. There was a mess with tab character usage. Indention with spaces and tabs was mixed inconsistently sometimes with obviously different assumptions on tab width, even in the same file. This results in irregular, hard to read indents. Please stop using tabs in source code.
2. Clean up of space at end of line.
3. Clean up of empty lines at end of file.