### PR TITLE
Fix for Issue #66

### DIFF
--- a/src/pv/pvaClientMultiChannel.h
+++ b/src/pv/pvaClientMultiChannel.h
@@ -577,6 +577,11 @@ public:
     {
         return shared_from_this();
     }
+    /**
+     * @brief Get channel change flags.
+     * @return Array of boolean fields that are set to true if corresponding channel changed
+     */
+    std::vector<bool> getChannelChangeFlags() const;
 private:
     PvaClientNTMultiData(
          epics::pvData::UnionConstPtr const & u,

--- a/src/pvaClientNTMultiData.cpp
+++ b/src/pvaClientNTMultiData.cpp
@@ -214,4 +214,13 @@ NTMultiChannelPtr PvaClientNTMultiData::getNTMultiChannel()
     return ntMultiChannel;
 }
 
+std::vector<bool> PvaClientNTMultiData::getChannelChangeFlags() const
+{
+    std::vector<bool> changeFlags(nchannel);
+    for(size_t i=0; i<nchannel; ++i) {
+        changeFlags[i] = (secondsPastEpoch[i] > 0);
+    }
+    return changeFlags;
+}
+
 }}

--- a/src/pvaClientNTMultiData.cpp
+++ b/src/pvaClientNTMultiData.cpp
@@ -127,7 +127,7 @@ void PvaClientNTMultiData::endDeltaTime(bool valueOnly)
     {
         PVStructurePtr pvst = topPVStructure[i];
         if(!pvst) {
-            unionValue[i] = PVUnionPtr();
+            // This channel has not changed value.
         } else if(unionValue[i]) {
             if(valueOnly) {
                 PVFieldPtr pvValue = pvst->getSubField("value");


### PR DESCRIPTION
This PR resolves issue #66 and contains fix for problem where multichannel monitor sets to none values for all channels that do not change, as well as convenience API method that allows checking which channels have changed their values. 